### PR TITLE
Add nullable check for obsRefetch

### DIFF
--- a/src/react/data/QueryData.ts
+++ b/src/react/data/QueryData.ts
@@ -446,7 +446,7 @@ export class QueryData<TData, TVariables> extends OperationData {
   }
 
   private obsRefetch = (variables?: Partial<TVariables>) =>
-    this.currentObservable!.refetch(variables);
+    this.currentObservable?.refetch(variables);
 
   private obsFetchMore = <K extends keyof TVariables>(
     fetchMoreOptions: FetchMoreQueryOptions<TVariables, K> &


### PR DESCRIPTION
https://github.com/apollographql/apollo-client/issues/5870

To fix the following issue when RN's FastRefresh triggers obsRefetch

<img width="300" alt="Screen Shot 2020-10-17 at 17 52 21" src="https://user-images.githubusercontent.com/10094591/96333029-8100ed00-10a2-11eb-9b2f-3d8e809b9251.png">
